### PR TITLE
Account for values on both size of 360

### DIFF
--- a/MapboxNavigation/Geometry.swift
+++ b/MapboxNavigation/Geometry.swift
@@ -315,3 +315,12 @@ extension CLLocation {
         return closestCoordinate.distance < maximumDistance
     }
 }
+
+
+/*
+ Returns the smallest angle between two angles
+ */
+func smallestAngle(alpha: Double, beta: Double) -> Double {
+    let phi = abs(beta - alpha).truncatingRemainder(dividingBy: 360);
+    return phi > 180 ? 360 - phi : phi;
+}

--- a/MapboxNavigation/RouteController.swift
+++ b/MapboxNavigation/RouteController.swift
@@ -129,7 +129,7 @@ extension RouteController: CLLocationManagerDelegate {
         if let finalHeading = routeProgress.currentLegProgress.upComingStep?.finalHeading {
             let finalHeadingNormalized = wrap(finalHeading, min: 0, max: 360)
             let userHeadingNormalized = wrap(location.course, min: 0, max: 360)
-            courseMatchesManeuverFinalHeading = abs((finalHeadingNormalized - userHeadingNormalized) - 360) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
+            courseMatchesManeuverFinalHeading = abs((finalHeadingNormalized - userHeadingNormalized)) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion || abs((finalHeadingNormalized - userHeadingNormalized) - 360) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
         }
         
         if userSnapToStepDistanceFromManeuver <= RouteControllerManeuverZoneRadius {

--- a/MapboxNavigation/RouteController.swift
+++ b/MapboxNavigation/RouteController.swift
@@ -129,7 +129,7 @@ extension RouteController: CLLocationManagerDelegate {
         if let finalHeading = routeProgress.currentLegProgress.upComingStep?.finalHeading {
             let finalHeadingNormalized = wrap(finalHeading, min: 0, max: 360)
             let userHeadingNormalized = wrap(location.course, min: 0, max: 360)
-            courseMatchesManeuverFinalHeading = abs(finalHeadingNormalized - userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
+            courseMatchesManeuverFinalHeading = abs((finalHeadingNormalized - userHeadingNormalized) - 360) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
         }
         
         if userSnapToStepDistanceFromManeuver <= RouteControllerManeuverZoneRadius {

--- a/MapboxNavigation/RouteController.swift
+++ b/MapboxNavigation/RouteController.swift
@@ -129,7 +129,7 @@ extension RouteController: CLLocationManagerDelegate {
         if let finalHeading = routeProgress.currentLegProgress.upComingStep?.finalHeading {
             let finalHeadingNormalized = wrap(finalHeading, min: 0, max: 360)
             let userHeadingNormalized = wrap(location.course, min: 0, max: 360)
-            courseMatchesManeuverFinalHeading = abs((finalHeadingNormalized - userHeadingNormalized)) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion || abs((finalHeadingNormalized - userHeadingNormalized) - 360) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
+            courseMatchesManeuverFinalHeading = smallestAngle(alpha: finalHeadingNormalized, beta: userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
         }
         
         if userSnapToStepDistanceFromManeuver <= RouteControllerManeuverZoneRadius {

--- a/MapboxNavigationTests/MapboxNavigationTests.swift
+++ b/MapboxNavigationTests/MapboxNavigationTests.swift
@@ -43,7 +43,7 @@ class MapboxNavigationTests: XCTestCase {
     func testLowAlert() {
         let navigation = RouteController(route: route)
         navigation.resume()
-        let user = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.789107313165275, longitude: -122.43219584226608), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
+        let user = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.79163, longitude: -122.412479), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 261, speed: 10, timestamp: Date())
         
         self.expectation(forNotification: RouteControllerAlertLevelDidChange.rawValue, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 3)
@@ -52,10 +52,10 @@ class MapboxNavigationTests: XCTestCase {
             let userDistance = notification.userInfo![RouteControllerAlertLevelDidChangeNotificationDistanceToEndOfManeuverKey] as! CLLocationDistance
             let firstAlert = notification.userInfo![RouteControllerProgressDidChangeNotificationIsFirstAlertForStepKey] as? Bool
             
-            return routeProgress?.currentLegProgress.alertUserLevel == .low && routeProgress?.currentLegProgress.stepIndex == 2 && round(userDistance) == 1785 && firstAlert == true
+            return routeProgress?.currentLegProgress.alertUserLevel == .low && routeProgress?.currentLegProgress.stepIndex == 1 && round(userDistance) == 1758 && firstAlert == true
         }
         
-        navigation.routeProgress.currentLegProgress.stepIndex = 1
+        navigation.routeProgress.currentLegProgress.stepIndex = 0
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [user])
         
         waitForExpectations(timeout: waitForInterval)


### PR DESCRIPTION
Ran into a situation today where the maneuver final heading was `358` degrees and the user heading never crossed from 0 to `35x` (the user heading remained around 4 which is an acceptable heading for this example). Thus, the difference between the user heading and the final heading was ~354 degrees. 

This change normalizes the difference between the user and final heading further. 
