### PR TITLE
Specify swift version

### DIFF
--- a/MapboxNavigation.swift.podspec
+++ b/MapboxNavigation.swift.podspec
@@ -41,4 +41,8 @@ Pod::Spec.new do |s|
 
   s.dependency "MapboxDirections.swift"
 
+  s.xcconfig = {
+    "SWIFT_VERSION" => "3.0"
+  }
+
 end

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -788,6 +788,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -834,6 +835,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -859,7 +861,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -880,7 +881,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Mapbox.MapboxNavigation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Fixes #14 

The [swiftenv](https://github.com/kylef/swiftenv) inspired `.swift-version`-file is flaky despite CocoaPod's claim to support it as of 1.1.0.

This PR removes SWIFT_VERSION from the target and inherits it from the project instead.
It also specifies SWIFT_VERSION in xcconfig just like [MapboxDirections.swift.podspec](https://github.com/mapbox/MapboxDirections.swift/blob/swift3/MapboxDirections.swift.podspec#L48) which been proven to work well. These settings will continue to work when we add support for Carthage (#24)