### PR TITLE
Auto announce first step

### DIFF
--- a/Example/Swift/ViewController.swift
+++ b/Example/Swift/ViewController.swift
@@ -134,8 +134,6 @@ class ViewController: UIViewController, MGLMapViewDelegate, AVSpeechSynthesizerD
             self.navigation?.routeProgress = RouteProgress(route: self.userRoute!)
             self.navigation?.routeProgress.currentLegProgress.stepIndex = 0
         }
-
-        speak("Rerouted")
     }
     
     func getRoute(didFinish: (()->())? = nil) {

--- a/Example/Swift/ViewController.swift
+++ b/Example/Swift/ViewController.swift
@@ -132,6 +132,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, AVSpeechSynthesizerD
              Otherwise, it will continue to compare the user to the old route and continually reroute the user.
              */
             self.navigation?.routeProgress = RouteProgress(route: self.userRoute!)
+            self.navigation?.routeProgress.currentLegProgress.stepIndex = 0
         }
 
         speak("Rerouted")

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ In the event of a reroute, it's necessary to update the current route with a new
 
 ```swift
 navigation.routeProgress = RouteProgress(route: newRoute)
+navigation.routeProgress.currentLegProgress.stepIndex = 0
 ```
 
 ## Running the example app


### PR DESCRIPTION
Closes: https://github.com/mapbox/MapboxNavigation.swift/issues/32

This fixes the issue but as a follow-up task, I'd like to encapsulate these two lines into some sort of utility function that is called after rerouting with a new rotue.

Thoughts:

* On `didSet` of the `route`, reset the `stepIndex` to 0
* These two ([1](https://github.com/mapbox/MapboxNavigation.swift/blob/49bd57310e02dc81e098648aea6cc32abb3a376c/Example/Swift/ViewController.swift#L134), [2](https://github.com/mapbox/MapboxNavigation.swift/blob/49bd57310e02dc81e098648aea6cc32abb3a376c/Example/Swift/ViewController.swift#L203)) lines should be identical

/cc @1ec5 