### PR TITLE
Use Carthage submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,17 @@
+[submodule "Carthage/Checkouts/MapboxGeocoder.swift"]
+	path = Carthage/Checkouts/MapboxGeocoder.swift
+	url = https://github.com/mapbox/MapboxGeocoder.swift.git
+[submodule "Carthage/Checkouts/Polyline"]
+	path = Carthage/Checkouts/Polyline
+	url = https://github.com/raphaelmor/Polyline.git
+[submodule "Carthage/Checkouts/MapboxDirections.swift"]
+	path = Carthage/Checkouts/MapboxDirections.swift
+	url = https://github.com/mapbox/MapboxDirections.swift.git
+[submodule "Carthage/Checkouts/osrm-text-instructions.swift"]
+	url = https://github.com/Project-OSRM/osrm-text-instructions.swift.git
+[submodule "Carthage/Checkouts/Pulley"]
+	path = Carthage/Checkouts/Pulley
+	url = https://github.com/52inc/Pulley.git
+[submodule "Carthage/Checkouts/SDWebImage"]
+	path = Carthage/Checkouts/SDWebImage
+	url = https://github.com/rs/SDWebImage.git

--- a/Deps.xcworkspace/contents.xcworkspacedata
+++ b/Deps.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Carthage/Checkouts/Polyline/Polyline.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Carthage/Checkouts/osrm-text-instructions.swift/OSRMTextInstructions.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Carthage/Checkouts/MapboxDirections.swift/MapboxDirections.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Carthage/Checkouts/MapboxGeocoder.swift/MapboxGeocoder.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
Switched to Carthage submodules.
Note that you should  `--use-submodules` along with every checkout or update command.

Added a workspace that links to all dependencies we're actively developing for convenience.

@bsudekum 👀 