### PR TITLE
Include voice in NavUI

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -19,15 +19,11 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     @IBOutlet weak var toggleNavigationButton: UIButton!
     @IBOutlet weak var howToBeginLabel: UILabel!
     
-    var routeVoiceController = RouteVoiceController()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         mapView.delegate = self
-        
-        // If you want to use Polly instead of the built-in speech synthesizer, just set the identityPoolId
-        //routeVoiceController.identityPoolId = "<#Your AWS IdentityPoolId.#>"
         
         mapView.userTrackingMode = .follow
         resumeNotifications()
@@ -35,7 +31,6 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     
     deinit {
         suspendNotifications()
-        routeVoiceController.suspendNotifications()
         navigation?.suspendLocationUpdates()
     }
     

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -151,6 +151,12 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         // 1. the route the user will take
         // 2. A `Directions` class, used for rerouting.
         let viewController = NavigationUI.routeViewController(for: route)
+        
+        // If you'd like to use AWS Polly, provide your IdentityPoolId below
+        // `identityPoolId` is a required value for using AWS Polly voice instead of iOS's built in AVSpeechSynthesizer
+        // You can get a token here: http://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth-aws-identity-for-ios.html
+        // viewController.voiceController?.identityPoolId = "<#Your AWS IdentityPoolId. Remove Argument if you do not want to use AWS Polly#>"
+        
         present(viewController, animated: true, completion: nil)
     }
     

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -19,14 +19,15 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     @IBOutlet weak var toggleNavigationButton: UIButton!
     @IBOutlet weak var howToBeginLabel: UILabel!
     
-    // `identityPoolId` is a required value for using AWS Polly voice instead of iOS's built in AVSpeechSynthesizer
-    // You can get a token here: http://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth-aws-identity-for-ios.html
-    var routeVoiceController = RouteVoiceController(identityPoolId: "<#Your AWS IdentityPoolId. Remove Argument if you do not want to use AWS Polly#>")
+    var routeVoiceController = RouteVoiceController()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         mapView.delegate = self
+        
+        // If you want to use Polly instead of the built-in speech synthesizer, just set the identityPoolId
+        //routeVoiceController.identityPoolId = "<#Your AWS IdentityPoolId.#>"
         
         mapView.userTrackingMode = .follow
         resumeNotifications()

--- a/MapboxNavigation.swift.podspec
+++ b/MapboxNavigation.swift.podspec
@@ -40,7 +40,6 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxDirections.swift"
-  s.dependency "AWSPolly"
   s.dependency "OSRMTextInstructions"
 
   s.xcconfig = {

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -96,12 +96,12 @@
 		35B711D41E5E7AD2001EDA8D /* MapboxNavigationUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 351BEBD71E5BCC28006FE110 /* MapboxNavigationUI.framework */; };
 		35B839491E2E3D5D0045A868 /* MBRouteController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B839481E2E3D5D0045A868 /* MBRouteController.m */; };
 		35C6A35B1E5E418D0004CA57 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35C6A34D1E5E418D0004CA57 /* ViewController.m */; };
+		35C996F31E71CE6100544D1C /* RouteVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C561DF5A1E650EBF004137B8 /* RouteVoiceController.swift */; };
 		35D457A71E2D253100A89946 /* MBRouteController.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D457A61E2D253100A89946 /* MBRouteController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C52AC1261DF0E48600396B9F /* RouteProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52AC1251DF0E48600396B9F /* RouteProgressTests.swift */; };
 		C52D09CC1DEF444D00BE3C5C /* GeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52D09CB1DEF444D00BE3C5C /* GeometryTests.swift */; };
 		C52D09CE1DEF5E5100BE3C5C /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = C52D09CD1DEF5E5100BE3C5C /* route.json */; };
 		C52D09D31DEF636C00BE3C5C /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52D09D21DEF636C00BE3C5C /* Fixture.swift */; };
-		C561DF5B1E650EBF004137B8 /* RouteVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C561DF5A1E650EBF004137B8 /* RouteVoiceController.swift */; };
 		C561DF5D1E650EC8004137B8 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C561DF5C1E650EC8004137B8 /* DistanceFormatter.swift */; };
 		C561DF5F1E650ED3004137B8 /* RouteStepFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C561DF5E1E650ED3004137B8 /* RouteStepFormatter.swift */; };
 		C58D6BAD1DDCF2AE00387F53 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58D6BAC1DDCF2AE00387F53 /* Constants.swift */; };
@@ -1081,13 +1081,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C561DF5B1E650EBF004137B8 /* RouteVoiceController.swift in Sources */,
 				C5C94C1C1DDCD2340097296A /* RouteController.swift in Sources */,
 				C561DF5F1E650ED3004137B8 /* RouteStepFormatter.swift in Sources */,
 				C5C94C1E1DDCD23A0097296A /* Geometry.swift in Sources */,
 				35B839491E2E3D5D0045A868 /* MBRouteController.m in Sources */,
 				C561DF5D1E650EC8004137B8 /* DistanceFormatter.swift in Sources */,
 				C5C94C1D1DDCD2370097296A /* RouteProgress.swift in Sources */,
+				35C996F31E71CE6100544D1C /* RouteVoiceController.swift in Sources */,
 				C58D6BAD1DDCF2AE00387F53 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		35002D5E1E5F6ABB0090E733 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 35002D5D1E5F6ABB0090E733 /* Info.plist */; };
 		35002D611E5F6ADB0090E733 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35002D5F1E5F6ADB0090E733 /* Assets.xcassets */; };
 		35002D621E5F6ADB0090E733 /* Base.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 35002D601E5F6ADB0090E733 /* Base.lproj */; };
 		35002D691E5F6B2F0090E733 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 35002D661E5F6B1B0090E733 /* Main.storyboard */; };
@@ -92,18 +91,19 @@
 		354BD4F51E6637D500AE1344 /* AWSPolly.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 354BD4F11E6634C500AE1344 /* AWSPolly.framework */; };
 		358D14661E5E3B7700ADE590 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358D14651E5E3B7700ADE590 /* AppDelegate.swift */; };
 		358D14681E5E3B7700ADE590 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358D14671E5E3B7700ADE590 /* ViewController.swift */; };
+		359D00CF1E732D7100C2E770 /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 354A01BC1E66259600D765C2 /* Polyline.framework */; };
 		35B711D21E5E7AD2001EDA8D /* MapboxNavigationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B711D11E5E7AD2001EDA8D /* MapboxNavigationUITests.swift */; };
 		35B711D41E5E7AD2001EDA8D /* MapboxNavigationUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 351BEBD71E5BCC28006FE110 /* MapboxNavigationUI.framework */; };
 		35B839491E2E3D5D0045A868 /* MBRouteController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B839481E2E3D5D0045A868 /* MBRouteController.m */; };
 		35C6A35B1E5E418D0004CA57 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35C6A34D1E5E418D0004CA57 /* ViewController.m */; };
-		35C996F31E71CE6100544D1C /* RouteVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C561DF5A1E650EBF004137B8 /* RouteVoiceController.swift */; };
+		35C9973F1E732C1B00544D1C /* RouteVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */; };
+		35C997411E732C5400544D1C /* RouteStepFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C997401E732C5400544D1C /* RouteStepFormatter.swift */; };
 		35D457A71E2D253100A89946 /* MBRouteController.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D457A61E2D253100A89946 /* MBRouteController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C52AC1261DF0E48600396B9F /* RouteProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52AC1251DF0E48600396B9F /* RouteProgressTests.swift */; };
 		C52D09CC1DEF444D00BE3C5C /* GeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52D09CB1DEF444D00BE3C5C /* GeometryTests.swift */; };
 		C52D09CE1DEF5E5100BE3C5C /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = C52D09CD1DEF5E5100BE3C5C /* route.json */; };
 		C52D09D31DEF636C00BE3C5C /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52D09D21DEF636C00BE3C5C /* Fixture.swift */; };
 		C561DF5D1E650EC8004137B8 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C561DF5C1E650EC8004137B8 /* DistanceFormatter.swift */; };
-		C561DF5F1E650ED3004137B8 /* RouteStepFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C561DF5E1E650ED3004137B8 /* RouteStepFormatter.swift */; };
 		C58D6BAD1DDCF2AE00387F53 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58D6BAC1DDCF2AE00387F53 /* Constants.swift */; };
 		C5ADFBD81DDCC7840011824B /* MapboxNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADFBD71DDCC7840011824B /* MapboxNavigationTests.swift */; };
 		C5C94C1B1DDCD22B0097296A /* MapboxNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = C5ADFBCC1DDCC7840011824B /* MapboxNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -305,14 +305,14 @@
 		35C6A3471E5E418D0004CA57 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		35C6A34C1E5E418D0004CA57 /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		35C6A34D1E5E418D0004CA57 /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteVoiceController.swift; sourceTree = "<group>"; };
+		35C997401E732C5400544D1C /* RouteStepFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteStepFormatter.swift; sourceTree = "<group>"; };
 		35D457A61E2D253100A89946 /* MBRouteController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBRouteController.h; sourceTree = "<group>"; };
 		C52AC1251DF0E48600396B9F /* RouteProgressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteProgressTests.swift; sourceTree = "<group>"; };
 		C52D09CB1DEF444D00BE3C5C /* GeometryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeometryTests.swift; sourceTree = "<group>"; };
 		C52D09CD1DEF5E5100BE3C5C /* route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = route.json; sourceTree = "<group>"; };
 		C52D09D21DEF636C00BE3C5C /* Fixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
-		C561DF5A1E650EBF004137B8 /* RouteVoiceController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteVoiceController.swift; sourceTree = "<group>"; };
 		C561DF5C1E650EC8004137B8 /* DistanceFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DistanceFormatter.swift; sourceTree = "<group>"; };
-		C561DF5E1E650ED3004137B8 /* RouteStepFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteStepFormatter.swift; sourceTree = "<group>"; };
 		C58D6BAC1DDCF2AE00387F53 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C5ADFBC91DDCC7840011824B /* MapboxNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5ADFBCC1DDCC7840011824B /* MapboxNavigation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapboxNavigation.h; sourceTree = "<group>"; };
@@ -385,6 +385,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				354A01B91E66256600D765C2 /* MapboxDirections.framework in Frameworks */,
+				359D00CF1E732D7100C2E770 /* Polyline.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -444,12 +445,14 @@
 				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
 				351BEBE01E5BCC63006FE110 /* NavigationUI.swift */,
 				351BEBE31E5BCC63006FE110 /* RouteManeuverViewController.swift */,
+				35C997401E732C5400544D1C /* RouteStepFormatter.swift */,
 				351BEBE41E5BCC63006FE110 /* RouteMapViewController.swift */,
 				351BEBE51E5BCC63006FE110 /* RoutePageViewController.swift */,
 				351BEBE71E5BCC63006FE110 /* RouteTableViewCell.swift */,
 				351BEBE81E5BCC63006FE110 /* RouteTableViewController.swift */,
 				351BEBE91E5BCC63006FE110 /* RouteTableViewHeaderView.swift */,
 				351BEBEA1E5BCC63006FE110 /* RouteViewController.swift */,
+				35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */,
 				351BEBEB1E5BCC63006FE110 /* String.swift */,
 				351BEBEC1E5BCC63006FE110 /* StyleButton.swift */,
 				351BEBED1E5BCC63006FE110 /* StyleKitArrows.swift */,
@@ -611,9 +614,7 @@
 				C5ADFBFD1DDCC9CE0011824B /* Geometry.swift */,
 				C5ADFBCD1DDCC7840011824B /* Info.plist */,
 				C58D6BAC1DDCF2AE00387F53 /* Constants.swift */,
-				C561DF5A1E650EBF004137B8 /* RouteVoiceController.swift */,
 				C561DF5C1E650EC8004137B8 /* DistanceFormatter.swift */,
-				C561DF5E1E650ED3004137B8 /* RouteStepFormatter.swift */,
 			);
 			path = MapboxNavigation;
 			sourceTree = "<group>";
@@ -923,7 +924,6 @@
 				35002D691E5F6B2F0090E733 /* Main.storyboard in Resources */,
 				35002D611E5F6ADB0090E733 /* Assets.xcassets in Resources */,
 				35002D621E5F6ADB0090E733 /* Base.lproj in Resources */,
-				35002D5E1E5F6ABB0090E733 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1016,8 +1016,10 @@
 				351BEBFD1E5BCC63006FE110 /* String.swift in Sources */,
 				351BEBFF1E5BCC63006FE110 /* StyleKitArrows.swift in Sources */,
 				351BEBF91E5BCC63006FE110 /* RouteTableViewCell.swift in Sources */,
+				35C9973F1E732C1B00544D1C /* RouteVoiceController.swift in Sources */,
 				351BEBFC1E5BCC63006FE110 /* RouteViewController.swift in Sources */,
 				351BEC0F1E5BCC72006FE110 /* Directions.swift in Sources */,
+				35C997411E732C5400544D1C /* RouteStepFormatter.swift in Sources */,
 				351BEBFB1E5BCC63006FE110 /* RouteTableViewHeaderView.swift in Sources */,
 				351BEBF61E5BCC63006FE110 /* RouteMapViewController.swift in Sources */,
 				351BEBF51E5BCC63006FE110 /* RouteManeuverViewController.swift in Sources */,
@@ -1082,12 +1084,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5C94C1C1DDCD2340097296A /* RouteController.swift in Sources */,
-				C561DF5F1E650ED3004137B8 /* RouteStepFormatter.swift in Sources */,
 				C5C94C1E1DDCD23A0097296A /* Geometry.swift in Sources */,
 				35B839491E2E3D5D0045A868 /* MBRouteController.m in Sources */,
 				C561DF5D1E650EC8004137B8 /* DistanceFormatter.swift in Sources */,
 				C5C94C1D1DDCD2370097296A /* RouteProgress.swift in Sources */,
-				35C996F31E71CE6100544D1C /* RouteVoiceController.swift in Sources */,
 				C58D6BAD1DDCF2AE00387F53 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -142,6 +142,8 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     }
     
     func alertLevelDidChange(notification: NSNotification) {
+        guard isEnabled == true else { return }
+        
         guard let routeProgress = notification.userInfo![RouteControllerAlertLevelDidChangeNotificationRouteProgressKey] as? RouteProgress else {
             assert(false)
             return
@@ -234,8 +236,6 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     }
     
     func speakWithPolly(_ text: String) {
-        guard isEnabled == true else { return }
-        
         assert(!text.isEmpty)
         
         speechSynth.delegate = self
@@ -323,8 +323,6 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     
     
     func speakFallBack(_ text: String, error: String? = nil) {
-        guard isEnabled == true else { return }
-        
         // Note why it failed
         if let error = error {
             print(error)

--- a/MapboxNavigationUI.swift.podspec
+++ b/MapboxNavigationUI.swift.podspec
@@ -49,6 +49,7 @@ Pod::Spec.new do |s|
   s.dependency "OSRMTextInstructions"
   s.dependency "Pulley"
   s.dependency "SDWebImage"
+  s.dependency "AWSPolly"
 
   s.xcconfig = {
     "SWIFT_VERSION" => "3.0"

--- a/MapboxNavigationUI/RouteStepFormatter.swift
+++ b/MapboxNavigationUI/RouteStepFormatter.swift
@@ -33,21 +33,3 @@ public class RouteStepFormatter: Formatter {
         return false
     }
 }
-
-
-public extension String {
-    typealias Replacement = (of: String, with: String)
-    
-    func byReplacing(_ replacements: [Replacement]) -> String {
-        return replacements.reduce(self) { $0.replacingOccurrences(of: $1.of, with: $1.with) }
-    }
-    
-    var addingXMLEscapes: String {
-        return byReplacing([
-            ("&", "&amp;"),
-            ("<", "&lt;"),
-            ("\"", "&quot;"),
-            ("'", "&apos;")
-            ])
-    }
-}

--- a/MapboxNavigationUI/RouteViewController.swift
+++ b/MapboxNavigationUI/RouteViewController.swift
@@ -55,6 +55,14 @@ public class RouteViewController: NavigationPulleyViewController {
     public var navigationDelegate: RouteViewControllerDelegate?
     
     /**
+     `voiceController` provides access to various speech synthesizer options.
+     
+     See `RouteVoiceController` for more information.
+     */
+    public var voiceController: RouteVoiceController? = RouteVoiceController()
+    
+    
+    /**
      `mapView` provides access to the navigation's `MGLMapView` with all its styling capabilities.
      
      Note that you should not change the `mapView`'s delegate.
@@ -86,6 +94,10 @@ public class RouteViewController: NavigationPulleyViewController {
         fatalError("init(contentViewController:drawerViewController:) has not been implemented. " +
                    "Use NavigationUI.routeViewController(for:directions:) if you are instantiating programmatically " +
                    "or a storyboard reference to Navigation if you are using storyboards.")
+    }
+    
+    deinit {
+        suspendNotifications()
     }
     
     override public func viewDidLoad() {
@@ -232,6 +244,7 @@ public class RouteViewController: NavigationPulleyViewController {
 
 extension RouteViewController: RouteTableViewHeaderViewDelegate {
     func didTapCancel() {
+        voiceController = nil
         if navigationDelegate?.routeViewControllerDidCancelNavigation(self) != nil {
             // The receiver should handle dismissal of the RouteViewController
         } else {

--- a/MapboxNavigationUI/RouteVoiceController.swift
+++ b/MapboxNavigationUI/RouteVoiceController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AVFoundation
 import MapboxDirections
+import MapboxNavigation
 import AWSPolly
 
 public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {


### PR DESCRIPTION
Fixes #69 

RouteViewController now keeps a ref to a RouteVoiceController.
An optional identityPoolId can be set if Polly is preferred over default speech synthesizer.
Also added a boolean to enable/disable voice.

Tail work for this PR would be to make the AWSPolly dependency optional but we might want to wait with that until this accepted proposal has been released: https://github.com/apple/swift-evolution/blob/master/proposals/0075-import-test.md

@bsudekum 👀 
