### PR TITLE
clear default values from the storyboard labels

### DIFF
--- a/MapboxNavigationUI/RouteTableViewHeaderView.swift
+++ b/MapboxNavigationUI/RouteTableViewHeaderView.swift
@@ -18,6 +18,12 @@ class RouteTableViewHeaderView: UIView {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        
+        //clear default values from the storyboard so user does not see a 'flash' of random values
+        distanceRemaining.text = ""
+        timeRemaining.text = ""
+        etaLabel.text = ""
+        
         dividerView.backgroundColor = NavigationUI.shared.lineColor
     }
     


### PR DESCRIPTION
Because the storyboard has default values, when the view first loads there is flash from the default values in the storyboard until the real values are shown. This is quite obvious when the users locale is metric because you see "8.3 mi" before the actual metre/km value is shown.

there are a number of ways to address this minor issue. you could update the labels in the storyboard or do it in this view or in the view controller. I thought it might be cleaner in the view awakeFromNib()?