### PR TITLE
Add custom minimum alert distances for Cycling/Walking/Driving

### DIFF
--- a/MapboxNavigation/Constants.swift
+++ b/MapboxNavigation/Constants.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreLocation
+import MapboxDirections
 
 public let RouteControllerProgressDidChangeNotificationProgressKey = MBRouteControllerProgressDidChangeNotificationProgressKey
 public let RouteControllerProgressDidChangeNotificationLocationKey = MBRouteControllerProgressDidChangeNotificationLocationKey
@@ -49,13 +50,41 @@ public var RouteControllerManeuverZoneRadius: CLLocationDistance = 40
 /*
  Distance in meters for the minimum length of a step for giving a `medium` alert.
 */
-public var RouteControllerMinimumDistanceForMediumAlert: CLLocationDistance = 400
+public var RouteControllerMinimumDistanceForMediumAlertDriving: CLLocationDistance = 400
+public var RouteControllerMinimumDistanceForMediumAlertCycling: CLLocationDistance = 200
+public var RouteControllerMinimumDistanceForMediumAlertWalking: CLLocationDistance = 100
+
+public func RouteControllerMinimumDistanceForMediumAlert(identifier: MBDirectionsProfileIdentifier) -> CLLocationDistance {
+    if identifier == .automobile || identifier == .automobileAvoidingTraffic {
+        return RouteControllerMinimumDistanceForMediumAlertDriving
+    } else if identifier == .cycling {
+        return RouteControllerMinimumDistanceForMediumAlertCycling
+    } else if identifier == .walking {
+        return RouteControllerMinimumDistanceForMediumAlertWalking
+    }
+    
+    return RouteControllerMinimumDistanceForMediumAlertDriving
+}
 
 
 /*
  Distance in meters for the minimum length of a step for giving a `high` alert.
  */
-public var RouteControllerMinimumDistanceForHighAlert: CLLocationDistance = 100
+public var RouteControllerMinimumDistanceForHighAlertDriving: CLLocationDistance = 100
+public var RouteControllerMinimumDistanceForHighAlertCycling: CLLocationDistance = 60
+public var RouteControllerMinimumDistanceForHighAlertWalking: CLLocationDistance = 20
+
+public func RouteControllerMinimumDistanceForHighAlert(identifier: MBDirectionsProfileIdentifier) -> CLLocationDistance {
+    if identifier == .automobile || identifier == .automobileAvoidingTraffic {
+        return RouteControllerMinimumDistanceForHighAlertDriving
+    } else if identifier == .cycling {
+        return RouteControllerMinimumDistanceForHighAlertCycling
+    } else if identifier == .walking {
+        return RouteControllerMinimumDistanceForHighAlertWalking
+    }
+    
+    return RouteControllerMinimumDistanceForHighAlertDriving
+}
 
 
 /*

--- a/MapboxNavigation/Constants.swift
+++ b/MapboxNavigation/Constants.swift
@@ -55,12 +55,17 @@ public var RouteControllerMinimumDistanceForMediumAlertCycling: CLLocationDistan
 public var RouteControllerMinimumDistanceForMediumAlertWalking: CLLocationDistance = 100
 
 public func RouteControllerMinimumDistanceForMediumAlert(identifier: MBDirectionsProfileIdentifier) -> CLLocationDistance {
-    if identifier == .automobile || identifier == .automobileAvoidingTraffic {
+    switch identifier {
+    case MBDirectionsProfileIdentifier.automobileAvoidingTraffic:
         return RouteControllerMinimumDistanceForMediumAlertDriving
-    } else if identifier == .cycling {
+    case MBDirectionsProfileIdentifier.automobile:
+        return RouteControllerMinimumDistanceForMediumAlertDriving
+    case MBDirectionsProfileIdentifier.cycling:
         return RouteControllerMinimumDistanceForMediumAlertCycling
-    } else if identifier == .walking {
+    case MBDirectionsProfileIdentifier.walking:
         return RouteControllerMinimumDistanceForMediumAlertWalking
+    default:
+        break
     }
     
     return RouteControllerMinimumDistanceForMediumAlertDriving
@@ -75,12 +80,17 @@ public var RouteControllerMinimumDistanceForHighAlertCycling: CLLocationDistance
 public var RouteControllerMinimumDistanceForHighAlertWalking: CLLocationDistance = 20
 
 public func RouteControllerMinimumDistanceForHighAlert(identifier: MBDirectionsProfileIdentifier) -> CLLocationDistance {
-    if identifier == .automobile || identifier == .automobileAvoidingTraffic {
+    switch identifier {
+    case MBDirectionsProfileIdentifier.automobileAvoidingTraffic:
         return RouteControllerMinimumDistanceForHighAlertDriving
-    } else if identifier == .cycling {
+    case MBDirectionsProfileIdentifier.automobile:
+        return RouteControllerMinimumDistanceForHighAlertDriving
+    case MBDirectionsProfileIdentifier.cycling:
         return RouteControllerMinimumDistanceForHighAlertCycling
-    } else if identifier == .walking {
+    case MBDirectionsProfileIdentifier.walking:
         return RouteControllerMinimumDistanceForHighAlertWalking
+    default:
+        break
     }
     
     return RouteControllerMinimumDistanceForHighAlertDriving

--- a/MapboxNavigation/RouteController.swift
+++ b/MapboxNavigation/RouteController.swift
@@ -118,10 +118,14 @@ extension RouteController: CLLocationManagerDelegate {
     func monitorStepProgress(_ location: CLLocation) {
         // Force an announcement when the user begins a route
         var alertLevel: AlertLevel = routeProgress.currentLegProgress.alertUserLevel == .none ? .depart : routeProgress.currentLegProgress.alertUserLevel
+        let profileIdentifier = routeProgress.route.profileIdentifier
         
         let userSnapToStepDistanceFromManeuver = distance(along: routeProgress.currentLegProgress.currentStep.coordinates!, from: location.coordinate)
         let secondsToEndOfStep = userSnapToStepDistanceFromManeuver / location.speed
         var courseMatchesManeuverFinalHeading = false
+        
+        let minimumDistanceForHighAlert = RouteControllerMinimumDistanceForHighAlert(identifier: profileIdentifier)
+        let minimumDistanceForMediumAlert = RouteControllerMinimumDistanceForMediumAlert(identifier: profileIdentifier)
         
         // Bearings need to normalized so when the `finalHeading` is 359 and the user heading is 1,
         // we count this as within the `RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion`
@@ -168,13 +172,13 @@ extension RouteController: CLLocationManagerDelegate {
                 let secondsToEndOfStep = userSnapToStepDistanceFromManeuver / location.speed
                 alertLevel = secondsToEndOfStep <= RouteControllerMediumAlertInterval ? .medium : .low
             }
-        } else if secondsToEndOfStep <= RouteControllerHighAlertInterval && routeProgress.currentLegProgress.currentStep.distance > RouteControllerMinimumDistanceForHighAlert {
+        } else if secondsToEndOfStep <= RouteControllerHighAlertInterval && routeProgress.currentLegProgress.currentStep.distance > minimumDistanceForHighAlert {
             alertLevel = .high
         } else if secondsToEndOfStep <= RouteControllerMediumAlertInterval &&
             // Don't alert if the route segment is shorter than X
             // However, if it's the beginning of the route
             // There needs to be an alert
-            routeProgress.currentLegProgress.currentStep.distance > RouteControllerMinimumDistanceForMediumAlert {
+            routeProgress.currentLegProgress.currentStep.distance > minimumDistanceForMediumAlert {
             alertLevel = .medium
         }
         


### PR DESCRIPTION
- Replace RouteControllerMinimumDistanceForMediumAlert and RouteControllerMinimumDistanceForHighAlert with
RouteControllerMinimumDistanceForHighAlertDriving, RouteControllerMinimumDistanceForHighAlertCycling, RouteControllerMinimumDistanceForHighAlertWalking
RouteControllerMinimumDistanceForMediumAlertDriving, RouteControllerMinimumDistanceForMediumAlertCycling, RouteControllerMinimumDistanceForMediumAlertWalking
to allow for different minimum distance per transportation method.

- Add RouteControllerMinimumDistanceForMediumAlert(identifier:) and RouteControllerMinimumDistanceForHighAlert(identifier:)
to choose which minimum distance is approriate for which MBDirectionsProfileIdentifier type.

- Modifiy MapboxNavigation/RouteController and MapboxNavigationUI/RouteVoiceController to use
new minimum distance values.

@bsudekum @1ec5 @boundsj 