### PR TITLE
Make RouteViewController respect original route profile identifier

### DIFF
--- a/MapboxNavigationUI/Directions.swift
+++ b/MapboxNavigationUI/Directions.swift
@@ -4,12 +4,12 @@ import MapboxDirections
 import UIKit
 
 extension RouteOptions {
-    class func preferredOptions(from origin: CLLocationCoordinate2D, to destination: CLLocationCoordinate2D, heading: CLLocationDirection? = nil, profileIdentifier: MBDirectionsProfileIdentifier? = nil) -> RouteOptions {
+    class func preferredOptions(from origin: CLLocationCoordinate2D, to destination: CLLocationCoordinate2D, heading: CLLocationDirection? = nil, profileIdentifier: MBDirectionsProfileIdentifier) -> RouteOptions {
         let options = RouteOptions(coordinates: [origin, destination])
         
         options.includesSteps = true
         options.routeShapeResolution = .full
-        options.profileIdentifier = profileIdentifier ?? .automobileAvoidingTraffic
+        options.profileIdentifier = profileIdentifier
         
         if let heading = heading, heading >= 0, let firstWaypoint = options.waypoints.first {
             firstWaypoint.heading = heading

--- a/MapboxNavigationUI/RouteViewController.swift
+++ b/MapboxNavigationUI/RouteViewController.swift
@@ -153,7 +153,7 @@ public class RouteViewController: NavigationPulleyViewController {
         let location = notification.userInfo![RouteControllerNotificationShouldRerouteKey] as! CLLocation
         routeTask?.cancel()
         
-        let options = RouteOptions.preferredOptions(from: location.coordinate, to: destination.coordinate, heading: location.course)
+        let options = RouteOptions.preferredOptions(from: location.coordinate, to: destination.coordinate, heading: location.course, profileIdentifier: route.profileIdentifier)
         routeTask = directions.calculate(options, completionHandler: { [weak self] (waypoints, routes, error) in
             guard let strongSelf = self else {
                 return


### PR DESCRIPTION
- When RouteViewController is re-calculating a route, pass through original
route.profileIdentifier to make sure the new route uses the same identifier.

- Remove default value for RouteOptions.preferredOptions() profileIdentifier
argument, since there should always be a value for it.

@bsudekum @1ec5 @boundsj 