### PR TITLE
Don't continual reroute user if standing still, allow user time to get to route start

### DIFF
--- a/MapboxNavigation/Constants.swift
+++ b/MapboxNavigation/Constants.swift
@@ -50,6 +50,10 @@ public var RouteControllerHighAlertInterval: TimeInterval = 15
 */
 public var RouteControllerManeuverZoneRadius: CLLocationDistance = 40
 
+
+/*
+ Maximum number of seconds the user can travel away from the start of the route before rerouting occurs
+*/
 public var MaxSecondsSpentTravelingAwayFromStartOfRoute: TimeInterval = 3
 
 

--- a/MapboxNavigation/Constants.swift
+++ b/MapboxNavigation/Constants.swift
@@ -50,6 +50,8 @@ public var RouteControllerHighAlertInterval: TimeInterval = 15
 */
 public var RouteControllerManeuverZoneRadius: CLLocationDistance = 40
 
+public var MaxSecondsSpentTravelingAwayFromStartOfRoute: TimeInterval = 3
+
 
 /*
  Distance in meters for the minimum length of a step for giving a `medium` alert.

--- a/MapboxNavigation/RouteController.swift
+++ b/MapboxNavigation/RouteController.swift
@@ -11,7 +11,7 @@ open class RouteController: NSObject {
     
     var lastUserDistanceToStartOfRoute = Double.infinity
     
-    var userIsMovingAwayFromStartCounter: Int = 0
+    var lastTimeStampSpentMovingAwayFromStart = Date()
     
     /*
      Monitor users location along route.
@@ -114,12 +114,8 @@ extension RouteController: CLLocationManagerDelegate {
                 return
             }
             
-            if userSnappedDistanceToClosestCoordinate > lastUserDistanceToStartOfRoute {
-                userIsMovingAwayFromStartCounter += 1
-            }
-            
-            // Wait until the user is moving 3 ticks away from the start of the route
-            guard userIsMovingAwayFromStartCounter > 3 else {
+            // Give the user x seconds of moving away from the start of the route before rerouting
+            guard Date().timeIntervalSince(lastTimeStampSpentMovingAwayFromStart) > MaxSecondsSpentTravelingAwayFromStartOfRoute else {
                 lastUserDistanceToStartOfRoute = userSnappedDistanceToClosestCoordinate
                 return
             }
@@ -131,6 +127,10 @@ extension RouteController: CLLocationManagerDelegate {
             }
             
             lastUserDistanceToStartOfRoute = userSnappedDistanceToClosestCoordinate
+            
+            if userSnappedDistanceToClosestCoordinate > lastUserDistanceToStartOfRoute {
+                lastTimeStampSpentMovingAwayFromStart = location.timestamp
+            }
         }
         
         guard userIsOnRoute(location) else {
@@ -145,7 +145,7 @@ extension RouteController: CLLocationManagerDelegate {
     }
     
     func resetStartCounter() {
-        userIsMovingAwayFromStartCounter = 0
+        lastTimeStampSpentMovingAwayFromStart = Date()
         lastUserDistanceToStartOfRoute = Double.infinity
     }
     

--- a/MapboxNavigation/RouteController.swift
+++ b/MapboxNavigation/RouteController.swift
@@ -107,8 +107,8 @@ extension RouteController: CLLocationManagerDelegate {
             }
         }
         
-        if routeProgress.currentLegProgress.currentStepProgress.step.maneuverType == .depart && !userIsOnRoute(location) {
-            let step = routeProgress.currentLegProgress.currentStepProgress.step
+        let step = routeProgress.currentLegProgress.currentStepProgress.step
+        if step.maneuverType == .depart && !userIsOnRoute(location) {
             
             guard let userSnappedDistanceToClosestCoordinate = closestCoordinate(on: step.coordinates!, to: location.coordinate)?.distance else {
                 return

--- a/MapboxNavigation/RouteController.swift
+++ b/MapboxNavigation/RouteController.swift
@@ -126,11 +126,11 @@ extension RouteController: CLLocationManagerDelegate {
                 return
             }
             
-            lastUserDistanceToStartOfRoute = userSnappedDistanceToClosestCoordinate
-            
             if userSnappedDistanceToClosestCoordinate > lastUserDistanceToStartOfRoute {
                 lastTimeStampSpentMovingAwayFromStart = location.timestamp
             }
+            
+            lastUserDistanceToStartOfRoute = userSnappedDistanceToClosestCoordinate
         }
         
         guard userIsOnRoute(location) else {

--- a/MapboxNavigationTests/MapboxNavigationTests.swift
+++ b/MapboxNavigationTests/MapboxNavigationTests.swift
@@ -63,8 +63,8 @@ class MapboxNavigationTests: XCTestCase {
         let navigation = RouteController(route: route)
         navigation.resume()
         
-        let reroutePoint1 = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 38, longitude: -123), altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date().addingTimeInterval(10))
-        let reroutePoint2 = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 38, longitude: -124), altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date().addingTimeInterval(20))
+        let reroutePoint1 = CLLocation(latitude: 38, longitude: -123)
+        let reroutePoint2 = CLLocation(latitude: 38, longitude: -124)
         
         self.expectation(forNotification: RouteControllerShouldReroute.rawValue, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)

--- a/MapboxNavigationTests/MapboxNavigationTests.swift
+++ b/MapboxNavigationTests/MapboxNavigationTests.swift
@@ -63,24 +63,21 @@ class MapboxNavigationTests: XCTestCase {
         let navigation = RouteController(route: route)
         navigation.resume()
         
-        let reroutePoint = CLLocation(latitude: 38, longitude: -123)
-        let reroutePoint1 = CLLocation(latitude: 38, longitude: -124)
-        let reroutePoint2 = CLLocation(latitude: 38, longitude: -125)
-        let reroutePoint3 = CLLocation(latitude: 38, longitude: -126)
-        let reroutePoint4 = CLLocation(latitude: 38, longitude: -127)
+        let reroutePoint1 = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 38, longitude: -123), altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date().addingTimeInterval(10))
+        let reroutePoint2 = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 38, longitude: -124), altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date().addingTimeInterval(20))
         
         self.expectation(forNotification: RouteControllerShouldReroute.rawValue, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
             
             let location = notification.userInfo![RouteControllerNotificationShouldRerouteKey] as? CLLocation
-            return location == reroutePoint4
+            return location == reroutePoint2
         }
         
-        navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint])
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint1])
-        navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint2])
-        navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint3])
-        navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint4])
+        
+        _ = Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { timer in
+            navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint2])
+        }
         
         waitForExpectations(timeout: waitForInterval)
     }

--- a/MapboxNavigationTests/MapboxNavigationTests.swift
+++ b/MapboxNavigationTests/MapboxNavigationTests.swift
@@ -62,16 +62,25 @@ class MapboxNavigationTests: XCTestCase {
     func testShouldReroute() {
         let navigation = RouteController(route: route)
         navigation.resume()
-        let reroutePoint = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 38, longitude: -123), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 0, speed: 10, timestamp: Date())
+        
+        let reroutePoint = CLLocation(latitude: 38, longitude: -123)
+        let reroutePoint1 = CLLocation(latitude: 38, longitude: -124)
+        let reroutePoint2 = CLLocation(latitude: 38, longitude: -125)
+        let reroutePoint3 = CLLocation(latitude: 38, longitude: -126)
+        let reroutePoint4 = CLLocation(latitude: 38, longitude: -127)
         
         self.expectation(forNotification: RouteControllerShouldReroute.rawValue, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
             
             let location = notification.userInfo![RouteControllerNotificationShouldRerouteKey] as? CLLocation
-            return location == reroutePoint
+            return location == reroutePoint4
         }
         
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint])
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint1])
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint2])
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint3])
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [reroutePoint4])
         
         waitForExpectations(timeout: waitForInterval)
     }


### PR DESCRIPTION
This addresses two issues:

1. A user is standing still far from the route. Consider if someone starts a route in a large parking lot. Yes, they are from the route, but we don't need to reroute them. 
1. The user is moving to/from the start. Again consider a large parking lot. If the user is traveling towards the beginning of the route, we do not need to reroute them even if they are greater than the max reroute distance.

/cc @frederoni @1ec5 