### PR TITLE
Add course snapping [wip]

### DIFF
--- a/MapboxNavigation/RouteProgress.swift
+++ b/MapboxNavigation/RouteProgress.swift
@@ -249,7 +249,9 @@ open class RouteLegProgress: NSObject {
         let priorCoords = priorStep?.coordinates ?? []
         let upcomingCoords = upComingStep?.coordinates ?? []
         let currentCoords = currentStep.coordinates ?? []
-        return priorCoords + currentCoords + upcomingCoords
+        let nearby = priorCoords + currentCoords + upcomingCoords
+        assert(!nearby.isEmpty, "Polyline must coordinates")
+        return nearby
     }
 }
 

--- a/MapboxNavigation/RouteProgress.swift
+++ b/MapboxNavigation/RouteProgress.swift
@@ -184,7 +184,7 @@ open class RouteLegProgress: NSObject {
      If there is no `priorStep`, nil is returned.
      */
     public var priorStep: RouteStep? {
-        guard stepIndex - 1 > 0 else {
+        guard stepIndex - 1 >= 0 else {
             return nil
         }
         return leg.steps[stepIndex - 1]

--- a/MapboxNavigation/RouteProgress.swift
+++ b/MapboxNavigation/RouteProgress.swift
@@ -178,6 +178,18 @@ open class RouteLegProgress: NSObject {
         return nil
     }
     
+    /*
+     Returns the `Step` before the current step.
+     
+     If there is no `priorStep`, nil is returned.
+     */
+    public var priorStep: RouteStep? {
+        guard stepIndex - 1 > 0 else {
+            return nil
+        }
+        return leg.steps[stepIndex - 1]
+    }
+    
     
     /*
      Returns number representing current `Step` for the leg the user is on.
@@ -227,6 +239,17 @@ open class RouteLegProgress: NSObject {
         self.leg = leg
         self.stepIndex = stepIndex
         currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex])
+    }
+    
+    
+    /*
+     Returns an array of `CLLocationCoordinate2D` of the prior, current and upcoming step geometry
+    */
+    public var priorCurrentUpcomingStepCoordinates: [CLLocationCoordinate2D] {
+        let priorCoords = priorStep?.coordinates ?? []
+        let upcomingCoords = upComingStep?.coordinates ?? []
+        let currentCoords = currentStep.coordinates ?? []
+        return priorCoords + currentCoords + upcomingCoords
     }
 }
 

--- a/MapboxNavigation/RouteProgress.swift
+++ b/MapboxNavigation/RouteProgress.swift
@@ -245,7 +245,7 @@ open class RouteLegProgress: NSObject {
     /*
      Returns an array of `CLLocationCoordinate2D` of the prior, current and upcoming step geometry
     */
-    public var priorCurrentUpcomingStepCoordinates: [CLLocationCoordinate2D] {
+    public var nearbyCoordinates: [CLLocationCoordinate2D] {
         let priorCoords = priorStep?.coordinates ?? []
         let upcomingCoords = upComingStep?.coordinates ?? []
         let currentCoords = currentStep.coordinates ?? []

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -246,24 +246,23 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         let userDistanceBuffer = location.speed * RouteControllerDeadReckoningTimeInterval
         
         // Get closest point infront of user
-        let infrontPointOne = coordinate(at: userDistanceBuffer, fromStartOf: slicedLine)!
-        let infrontClosest = closestCoordinate(on: coords, to: infrontPointOne)!
+        let pointOneSliced = coordinate(at: userDistanceBuffer, fromStartOf: slicedLine)!
+        let pointOneClosest = closestCoordinate(on: coords, to: pointOneSliced)!
         
-        // Get closest point behind in front of user
-        let infrontPointTwo = coordinate(at: userDistanceBuffer * 1.5, fromStartOf: slicedLine)!
-        let behindClosest = closestCoordinate(on: coords, to: infrontPointTwo)!
+        let pointTwoSliced = coordinate(at: userDistanceBuffer * 1.5, fromStartOf: slicedLine)!
+        let pointTwoClosest = closestCoordinate(on: coords, to: pointTwoSliced)!
         
         // Get direction of these points
-        let infrontDirection = closest.coordinate.direction(to: infrontClosest.coordinate)
-        let behindDirection = closest.coordinate.direction(to: behindClosest.coordinate)
+        let pointOneDirection = closest.coordinate.direction(to: pointOneClosest.coordinate)
+        let pointTwoDirection = closest.coordinate.direction(to: pointTwoClosest.coordinate)
         
-        let wrappedInFront = wrap(infrontDirection, min: -180, max: 180)
-        let wrappedBehind = wrap(behindDirection, min: -180, max: 180)
+        let wrappedPointOne = wrap(pointOneDirection, min: -180, max: 180)
+        let wrappedPointTwo = wrap(pointTwoDirection, min: -180, max: 180)
         
-        let relativeAngleInFront = differenceBetweenAngles(location.course, wrappedInFront)
-        let relativeAngleBehind = differenceBetweenAngles(location.course, wrappedBehind)
+        let relativeAnglepointOne = differenceBetweenAngles(location.course, wrappedPointOne)
+        let relativeAnglepointTwo = differenceBetweenAngles(location.course, wrappedPointTwo)
         
-        let averageRelativeAngle = (relativeAngleInFront + relativeAngleBehind) / 2
+        let averageRelativeAngle = (relativeAnglepointOne + relativeAnglepointTwo) / 2
 
         let absoluteDirection = wrap(location.course + averageRelativeAngle, min: 0 , max: 360)
         

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -249,7 +249,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         let pointOneSliced = coordinate(at: userDistanceBuffer, fromStartOf: slicedLine)!
         let pointOneClosest = closestCoordinate(on: coords, to: pointOneSliced)!
         
-        let pointTwoSliced = coordinate(at: userDistanceBuffer * 1.5, fromStartOf: slicedLine)!
+        let pointTwoSliced = coordinate(at: userDistanceBuffer * 2, fromStartOf: slicedLine)!
         let pointTwoClosest = closestCoordinate(on: coords, to: pointTwoSliced)!
         
         // Get direction of these points
@@ -258,13 +258,14 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         
         let wrappedPointOne = wrap(pointOneDirection, min: -180, max: 180)
         let wrappedPointTwo = wrap(pointTwoDirection, min: -180, max: 180)
+        let wrappedCourse = wrap(location.course, min: -180, max: 180)
         
-        let relativeAnglepointOne = differenceBetweenAngles(location.course, wrappedPointOne)
-        let relativeAnglepointTwo = differenceBetweenAngles(location.course, wrappedPointTwo)
+        let relativeAnglepointOne = wrap(wrappedPointOne - wrappedCourse, min: -180, max: 180)
+        let relativeAnglepointTwo = wrap(wrappedPointTwo - wrappedCourse, min: -180, max: 180)
         
         let averageRelativeAngle = (relativeAnglepointOne + relativeAnglepointTwo) / 2
 
-        let absoluteDirection = wrap(location.course + averageRelativeAngle, min: 0 , max: 360)
+        let absoluteDirection = wrap(wrappedCourse + averageRelativeAngle, min: 0 , max: 360)
         
         let course = averageRelativeAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion ? absoluteDirection : location.course
         

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -230,8 +230,24 @@ extension RouteMapViewController: NavigationMapViewDelegate {
                 newCoordinate = coordinate
             }
         }
+        let coords = routeController.routeProgress.route.coordinates!
+        let closest = closestCoordinate(on: coords, to: location.coordinate)
+        let slicedLine = polyline(along: coords, from: closest!.coordinate, to: coords.last)
         
-        return CLLocation(coordinate: newCoordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: location.course, speed: location.speed, timestamp: location.timestamp)
+        let infrontPointOne = coordinate(at: 2, fromStartOf: slicedLine)
+        let cloestInfront = closestCoordinate(on: coords, to: infrontPointOne!)
+        
+        let infrontPointTwo = coordinate(at: 4, fromStartOf: slicedLine)
+        let cloestBehind = closestCoordinate(on: coords, to: infrontPointTwo!)
+        
+        let infrontDirection = closest?.coordinate.direction(to: cloestInfront!.coordinate)
+        let behindDirection = closest?.coordinate.direction(to: cloestBehind!.coordinate)
+        
+        let normalizedCourse = wrap((infrontDirection! + behindDirection!) / 2, min: 0, max: 360)
+        let course = differenceBetweenAngles(location.course, normalizedCourse) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion ? normalizedCourse : location.course
+        
+        
+        return CLLocation(coordinate: newCoordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)
     }
 }
 

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -250,7 +250,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         let infrontClosest = closestCoordinate(on: coords, to: infrontPointOne)!
         
         // Get closest point behind in front of user
-        let infrontPointTwo = coordinate(at: userDistanceBuffer * 2, fromStartOf: slicedLine)!
+        let infrontPointTwo = coordinate(at: userDistanceBuffer * 1.5, fromStartOf: slicedLine)!
         let behindClosest = closestCoordinate(on: coords, to: infrontPointTwo)!
         
         // Get direction of these points
@@ -264,9 +264,8 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         let relativeAngleBehind = differenceBetweenAngles(location.course, wrappedBehind)
         
         let averageRelativeAngle = (relativeAngleInFront + relativeAngleBehind) / 2
-        let wrappedAverage = (wrappedInFront + wrappedBehind) / 2
 
-        let absoluteDirection = wrap(min(relativeAngleInFront, relativeAngleBehind) + wrappedAverage, min: 0, max: 360)
+        let absoluteDirection = wrap(location.course + averageRelativeAngle, min: 0 , max: 360)
         
         let course = averageRelativeAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion ? absoluteDirection : location.course
         

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -237,7 +237,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
             return defaultReturn
         }
         
-        let coords = routeController.routeProgress.currentLegProgress.priorCurrentUpcomingStepCoordinates
+        let coords = routeController.routeProgress.currentLegProgress.nearbyCoordinates
         assert(!coords.isEmpty)
         
         let closest = closestCoordinate(on: coords, to: location.coordinate)!


### PR DESCRIPTION
Adds course snapping to the `snapsUserLocationAnnotationToRoute` option.

More ideas on implemenation should be explored.

/cc @1ec5 