### PR TITLE
Insert route below text on reroute

### DIFF
--- a/MapboxNavigationUI/MGLMapView.swift
+++ b/MapboxNavigationUI/MGLMapView.swift
@@ -89,6 +89,10 @@ extension MGLMapView {
         let maneuverCoordinate = routeProgress.currentLegProgress.upComingStep?.maneuverLocation
         let polylineCoordinates = routeProgress.route.coordinates
         
+        guard let style = style else {
+            return
+        }
+        
         let shaftLength = max(min(50 * metersPerPoint(atLatitude: maneuverCoordinate!.latitude), 50), 10)
         let shaftCoordinates = polyline(along: polylineCoordinates!, within: -shaftLength / 2, of: maneuverCoordinate!)
             + polyline(along: polylineCoordinates!, within: shaftLength, of: maneuverCoordinate!)
@@ -145,11 +149,21 @@ extension MGLMapView {
             arrowStroke.lineWidth = MGLStyleValue(rawValue: 8)
             arrowStroke.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintColor)
             
-            style?.addSource(arrowSourceStroke)
-            style?.addSource(arrowSource)
+            if let source = style.source(withIdentifier: "arrowSource") {
+                let s = source as! MGLShapeSource
+                s.shape = MGLShapeCollection(shapes: maneuverArrowPolylines)
+            } else {
+                style.addSource(arrowSource)
+                style.addLayer(arrow)
+            }
             
-            style?.addLayer(arrow)
-            style?.insertLayer(arrowStroke, below: arrow)
+            if let source = style.source(withIdentifier: "arrowSourceStroke") {
+                let s = source as! MGLShapeSource
+                s.shape = MGLShapeCollection(shapes: maneuverArrowStrokePolylines)
+            } else {
+                style.addSource(arrowSourceStroke)
+                style.insertLayer(arrowStroke, below: arrow)
+            }
         }
     }
     

--- a/MapboxNavigationUI/MGLMapView.swift
+++ b/MapboxNavigationUI/MGLMapView.swift
@@ -166,26 +166,6 @@ extension MGLMapView {
             }
         }
     }
-    
-    func removeArrow() {
-        guard let style = style else { return }
-        
-        if let arrow = style.layer(withIdentifier: "arrow") {
-            style.removeLayer(arrow)
-        }
-        
-        if let arrow = style.layer(withIdentifier: "arrowStroke") {
-            style.removeLayer(arrow)
-        }
-        
-        if let arrowStrokeSourceCheck = style.source(withIdentifier: "arrowSourceStroke") {
-            style.removeSource(arrowStrokeSourceCheck)
-        }
-        
-        if let arrowSourceCheck = style.source(withIdentifier: "arrowSource") {
-            style.removeSource(arrowSourceCheck)
-        }
-    }
 }
 
 protocol NavigationMapViewDelegate {

--- a/MapboxNavigationUI/MGLMapView.swift
+++ b/MapboxNavigationUI/MGLMapView.swift
@@ -6,6 +6,9 @@ import MapboxNavigation
 let sourceIdentifier = "routeSource"
 let routeLayerIdentifier = "routeLayer"
 let routeLayerCasingIdentifier = "routeLayerCasing"
+let arrowSourceIdentifier = "arrowSource"
+let arrowSourceStrokeIdentifier = "arrowSourceStroke"
+let arrowLayerIdentifier = "arrowLayer"
 
 extension MGLMapView {
     
@@ -51,7 +54,8 @@ extension MGLMapView {
         style.addSource(geoJSONSource)
         
         for layer in style.layers.reversed() {
-            if let layer = layer as? MGLStyleLayer, !(layer is MGLSymbolStyleLayer) {
+            if let layer = layer as? MGLStyleLayer, !(layer is MGLSymbolStyleLayer) &&
+                layer.identifier != arrowLayerIdentifier && layer.identifier != arrowSourceIdentifier {
                 style.insertLayer(line, above: layer)
                 style.insertLayer(lineCasing, below: line)
                 return
@@ -128,15 +132,15 @@ extension MGLMapView {
             
             maneuverArrowPolylines.append(headStrokePolyline)
             
-            let arrowSource = MGLShapeSource(identifier: "arrowSource", shape: MGLShapeCollection(shapes: maneuverArrowPolylines), options: nil)
-            let arrow = MGLLineStyleLayer(identifier: "arrow", source: arrowSource)
+            let arrowSource = MGLShapeSource(identifier: arrowSourceIdentifier, shape: MGLShapeCollection(shapes: maneuverArrowPolylines), options: nil)
+            let arrow = MGLLineStyleLayer(identifier: arrowLayerIdentifier, source: arrowSource)
             
             arrow.lineWidth = MGLStyleValue(rawValue: 6)
             arrow.lineColor = MGLStyleValue(rawValue: .white)
             
             // Arrow stroke
-            let arrowSourceStroke = MGLShapeSource(identifier: "arrowSourceStroke", shape: MGLShapeCollection(shapes: maneuverArrowStrokePolylines), options: nil)
-            let arrowStroke = MGLLineStyleLayer(identifier: "arrowStroke", source: arrowSourceStroke)
+            let arrowSourceStroke = MGLShapeSource(identifier: arrowSourceStrokeIdentifier, shape: MGLShapeCollection(shapes: maneuverArrowStrokePolylines), options: nil)
+            let arrowStroke = MGLLineStyleLayer(identifier: arrowSourceIdentifier, source: arrowSourceStroke)
             
             let cap = NSValue(mglLineCap: .round)
             let join = NSValue(mglLineJoin: .round)
@@ -149,7 +153,7 @@ extension MGLMapView {
             arrowStroke.lineWidth = MGLStyleValue(rawValue: 8)
             arrowStroke.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintColor)
             
-            if let source = style.source(withIdentifier: "arrowSource") {
+            if let source = style.source(withIdentifier: arrowSourceIdentifier) {
                 let s = source as! MGLShapeSource
                 s.shape = MGLShapeCollection(shapes: maneuverArrowPolylines)
             } else {
@@ -157,7 +161,7 @@ extension MGLMapView {
                 style.addLayer(arrow)
             }
             
-            if let source = style.source(withIdentifier: "arrowSourceStroke") {
+            if let source = style.source(withIdentifier: arrowSourceStrokeIdentifier) {
                 let s = source as! MGLShapeSource
                 s.shape = MGLShapeCollection(shapes: maneuverArrowStrokePolylines)
             } else {

--- a/MapboxNavigationUI/MGLMapView.swift
+++ b/MapboxNavigationUI/MGLMapView.swift
@@ -9,8 +9,8 @@ let routeLayerCasingIdentifier = "routeLayerCasing"
 
 extension MGLMapView {
     
-    public func annotate(_ routes: [Route], clearMap: Bool) {
-        guard let route = routes.first, var coordinates = route.coordinates else {
+    public func annotate(_ route: Route) {
+        guard var coordinates = route.coordinates else {
             return
         }
         

--- a/MapboxNavigationUI/MGLMapView.swift
+++ b/MapboxNavigationUI/MGLMapView.swift
@@ -34,31 +34,35 @@ extension MGLMapView {
         }
         
         let polyline = MGLPolylineFeature(coordinates: &coordinates, count: route.coordinateCount)
-        let geoJSONSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
-        let line = MGLLineStyleLayer(identifier: routeLayerIdentifier, source: geoJSONSource)
-        let lineCasing = MGLLineStyleLayer(identifier: routeLayerCasingIdentifier, source: geoJSONSource)
         
-        line.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor.withAlphaComponent(0.6))
-        line.lineWidth = MGLStyleValue(rawValue: 5)
-        lineCasing.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor)
-        lineCasing.lineWidth = MGLStyleValue(rawValue: 9)
-        
-        let cap = NSValue(mglLineCap: .round)
-        let join = NSValue(mglLineJoin: .round)
-        
-        line.lineCap = MGLStyleValue(rawValue: cap)
-        line.lineJoin = MGLStyleValue(rawValue: join)
-        lineCasing.lineCap = MGLStyleValue(rawValue: cap)
-        lineCasing.lineJoin = MGLStyleValue(rawValue: join)
-        
-        style.addSource(geoJSONSource)
-        
-        for layer in style.layers.reversed() {
-            if let layer = layer as? MGLStyleLayer, !(layer is MGLSymbolStyleLayer) &&
-                layer.identifier != arrowLayerIdentifier && layer.identifier != arrowSourceIdentifier {
-                style.insertLayer(line, above: layer)
-                style.insertLayer(lineCasing, below: line)
-                return
+        if let source = style.source(withIdentifier: sourceIdentifier) as? MGLShapeSource {
+            source.shape = polyline
+        } else {
+            let geoJSONSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
+            let line = MGLLineStyleLayer(identifier: routeLayerIdentifier, source: geoJSONSource)
+            let lineCasing = MGLLineStyleLayer(identifier: routeLayerCasingIdentifier, source: geoJSONSource)
+            
+            line.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor.withAlphaComponent(0.6))
+            line.lineWidth = MGLStyleValue(rawValue: 5)
+            lineCasing.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor)
+            lineCasing.lineWidth = MGLStyleValue(rawValue: 9)
+            
+            let cap = NSValue(mglLineCap: .round)
+            let join = NSValue(mglLineJoin: .round)
+            
+            line.lineCap = MGLStyleValue(rawValue: cap)
+            line.lineJoin = MGLStyleValue(rawValue: join)
+            lineCasing.lineCap = MGLStyleValue(rawValue: cap)
+            lineCasing.lineJoin = MGLStyleValue(rawValue: join)
+            
+            style.addSource(geoJSONSource)
+            for layer in style.layers.reversed() {
+                if let layer = layer as? MGLStyleLayer, !(layer is MGLSymbolStyleLayer) &&
+                    layer.identifier != arrowLayerIdentifier && layer.identifier != arrowSourceIdentifier {
+                    style.insertLayer(line, above: layer)
+                    style.insertLayer(lineCasing, below: line)
+                    return
+                }
             }
         }
     }
@@ -132,39 +136,39 @@ extension MGLMapView {
             
             maneuverArrowPolylines.append(headStrokePolyline)
             
-            let arrowSource = MGLShapeSource(identifier: arrowSourceIdentifier, shape: MGLShapeCollection(shapes: maneuverArrowPolylines), options: nil)
-            let arrow = MGLLineStyleLayer(identifier: arrowLayerIdentifier, source: arrowSource)
-            
-            arrow.lineWidth = MGLStyleValue(rawValue: 6)
-            arrow.lineColor = MGLStyleValue(rawValue: .white)
-            
-            // Arrow stroke
-            let arrowSourceStroke = MGLShapeSource(identifier: arrowSourceStrokeIdentifier, shape: MGLShapeCollection(shapes: maneuverArrowStrokePolylines), options: nil)
-            let arrowStroke = MGLLineStyleLayer(identifier: arrowSourceIdentifier, source: arrowSourceStroke)
+            let arrowShape = MGLShapeCollection(shapes: maneuverArrowPolylines)
+            let arrowStrokeShape = MGLShapeCollection(shapes: maneuverArrowStrokePolylines)
             
             let cap = NSValue(mglLineCap: .round)
             let join = NSValue(mglLineJoin: .round)
             
-            arrowStroke.lineCap = MGLStyleValue(rawValue: cap)
-            arrowStroke.lineJoin = MGLStyleValue(rawValue: join)
-            arrow.lineCap = MGLStyleValue(rawValue: cap)
-            arrow.lineJoin = MGLStyleValue(rawValue: join)
+            let arrowSourceStroke = MGLShapeSource(identifier: arrowSourceStrokeIdentifier, shape: arrowStrokeShape, options: nil)
+            let arrowStroke = MGLLineStyleLayer(identifier: arrowSourceIdentifier, source: arrowSourceStroke)
+            let arrowSource = MGLShapeSource(identifier: arrowSourceIdentifier, shape: arrowShape, options: nil)
+            let arrow = MGLLineStyleLayer(identifier: arrowLayerIdentifier, source: arrowSource)
             
-            arrowStroke.lineWidth = MGLStyleValue(rawValue: 8)
-            arrowStroke.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintColor)
-            
-            if let source = style.source(withIdentifier: arrowSourceIdentifier) {
-                let s = source as! MGLShapeSource
-                s.shape = MGLShapeCollection(shapes: maneuverArrowPolylines)
+            if let source = style.source(withIdentifier: arrowSourceIdentifier) as? MGLShapeSource {
+                source.shape = arrowShape
             } else {
+                
+                arrow.lineCap = MGLStyleValue(rawValue: cap)
+                arrow.lineJoin = MGLStyleValue(rawValue: join)
+                arrow.lineWidth = MGLStyleValue(rawValue: 6)
+                arrow.lineColor = MGLStyleValue(rawValue: .white)
+                
                 style.addSource(arrowSource)
                 style.addLayer(arrow)
             }
             
-            if let source = style.source(withIdentifier: arrowSourceStrokeIdentifier) {
-                let s = source as! MGLShapeSource
-                s.shape = MGLShapeCollection(shapes: maneuverArrowStrokePolylines)
+            if let source = style.source(withIdentifier: arrowSourceStrokeIdentifier) as? MGLShapeSource {
+                source.shape = arrowStrokeShape
             } else {
+                
+                arrowStroke.lineCap = MGLStyleValue(rawValue: cap)
+                arrowStroke.lineJoin = MGLStyleValue(rawValue: join)
+                arrowStroke.lineWidth = MGLStyleValue(rawValue: 8)
+                arrowStroke.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintColor)
+                
                 style.addSource(arrowSourceStroke)
                 style.insertLayer(arrowStroke, below: arrow)
             }

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -123,6 +123,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     
     func notifyDidReroute(route: Route) {
         routePageViewController.notifyDidReRoute()
+        mapView.addArrow(routeController.routeProgress)
         mapView.annotate(route)
         mapView.userTrackingMode = .followWithCourse
     }

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -33,6 +33,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     let webImageManager = SDWebImageManager.shared()
     var shieldAPIDataTask: URLSessionDataTask?
     var shieldImageDownloadToken: SDWebImageDownloadToken?
+    var arrowCurrentStep: RouteStep?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -122,7 +123,8 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     
     func notifyDidReroute(route: Route) {
         routePageViewController.notifyDidReRoute()
-        mapView.annotate([route], clearMap: true)
+        mapView.removeArrow()
+        mapView.annotate(route)
         mapView.userTrackingMode = .followWithCourse
     }
     
@@ -210,12 +212,16 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     }
     
     func updateArrowAnnotations(_ routeProgress: RouteProgress) {
-        guard routeProgress.currentLegProgress.upComingStep != nil else {
+        guard let step = routeProgress.currentLegProgress.upComingStep else {
             return
         }
         
-        mapView.removeArrow()
-        mapView.addArrow(routeProgress)
+        if step != arrowCurrentStep {
+            mapView.removeArrow()
+            mapView.addArrow(routeProgress)
+        }
+        
+        arrowCurrentStep = step
     }
 }
 
@@ -288,7 +294,7 @@ extension RouteMapViewController: MGLMapViewDelegate {
     }
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
-        mapView.annotate([route], clearMap: false)
+        mapView.annotate(route)
     }
     
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -123,7 +123,6 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     
     func notifyDidReroute(route: Route) {
         routePageViewController.notifyDidReRoute()
-        mapView.removeArrow()
         mapView.annotate(route)
         mapView.userTrackingMode = .followWithCourse
     }
@@ -131,8 +130,6 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     func notifyAlertLevelDidChange(routeProgress: RouteProgress) {
         if routeProgress.currentLegProgress.followOnStep != nil {
             mapView.addArrow(routeProgress)
-        } else {
-            mapView.removeArrow()
         }
     }
     

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -130,7 +130,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     
     func notifyAlertLevelDidChange(routeProgress: RouteProgress) {
         if routeProgress.currentLegProgress.followOnStep != nil {
-            updateArrowAnnotations(routeProgress)
+            mapView.addArrow(routeProgress)
         } else {
             mapView.removeArrow()
         }
@@ -209,19 +209,6 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
                 completion(image)
             }
         }
-    }
-    
-    func updateArrowAnnotations(_ routeProgress: RouteProgress) {
-        guard let step = routeProgress.currentLegProgress.upComingStep else {
-            return
-        }
-        
-        if step != arrowCurrentStep {
-            mapView.removeArrow()
-            mapView.addArrow(routeProgress)
-        }
-        
-        arrowCurrentStep = step
     }
 }
 


### PR DESCRIPTION
* Cleans up the arguments for `annotate`
* Removes the arrow sooner when rerouting
* ^ This actually solves inserting the route line below labels. Before, we were inserting below the layer `arrow` instead.
* Only redraw the arrow when it actually changes.

closes: https://github.com/mapbox/MapboxNavigation.swift/issues/90 https://github.com/mapbox/MapboxNavigation.swift/issues/89

/cc @1ec5 