### PR TITLE
Adopt Swift 3.1

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.4
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.5
 github "mapbox/MapboxDirections.swift" ~> 0.8
 github "52inc/Pulley" ~> 1.3.1
 github "rs/SDWebImage" ~> 4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.4.2"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.5.0"
 github "52inc/Pulley" "1.3.1"
 github "Project-OSRM/osrm-text-instructions.swift" "bdd962bf5593f951bbbbd26435f732a829dacda7"
 github "frederoni/aws-sdk-ios" "1a8432b03c22326fb7ed86fac978212106e2d465"

--- a/MapboxNavigation/Geometry.swift
+++ b/MapboxNavigation/Geometry.swift
@@ -7,11 +7,11 @@ typealias RadianDirection = Double
 
 extension CLLocationDegrees {
     func toRadians() -> LocationRadians {
-        return self * M_PI / 180.0
+        return self * .pi / 180.0
     }
     
     func toDegrees() -> CLLocationDirection {
-        return self * 180.0 / M_PI
+        return self * 180.0 / .pi
     }
 }
 

--- a/MapboxNavigationUI/TurnArrowView.swift
+++ b/MapboxNavigationUI/TurnArrowView.swift
@@ -45,7 +45,7 @@ public class TurnArrowView: UIView {
         
         var flip: Bool = false
         let type: ManeuverType = step.maneuverType ?? .turn
-        let angle: Int = Int(wrap((step.finalHeading ?? CLLocationDirection.abs(0)) - (step.initialHeading ?? CLLocationDirection.abs(0)), min: -180, max: 180))
+        let angle: Int = Int(wrap((step.finalHeading ?? abs(0)) - (step.initialHeading ?? abs(0)), min: -180, max: 180))
         let direction: ManeuverDirection = step.maneuverDirection ?? ManeuverDirection(angle: angle)
 
         switch type {


### PR DESCRIPTION
Silenced warnings by updating deprecated methods and constants.
Also updated to Mapbox iOS SDK 3.5.0