### PR TITLE
Don't manipulate user puck course past certain point

### DIFF
--- a/MapboxNavigation/Constants.swift
+++ b/MapboxNavigation/Constants.swift
@@ -111,3 +111,9 @@ public func RouteControllerMinimumDistanceForHighAlert(identifier: MBDirectionsP
  When calculating whether or not the user is on the route, we look where the user will be given their speed and this variable.
 */
 public var RouteControllerDeadReckoningTimeInterval:TimeInterval = 1.0
+
+
+/*
+ Maximum angle the user puck will be rotated when snapping the user's course to the route line.
+*/
+public var RouteControllerMaxManipulatedCourseAngle:CLLocationDirection = 25

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -267,6 +267,10 @@ extension RouteMapViewController: NavigationMapViewDelegate {
 
         let absoluteDirection = wrap(wrappedCourse + averageRelativeAngle, min: 0 , max: 360)
         
+        guard differenceBetweenAngles(absoluteDirection, location.course) < RouteControllerMaxManipulatedCourseAngle else {
+            return defaultReturn
+        }
+        
         let course = averageRelativeAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion ? absoluteDirection : location.course
         
         return CLLocation(coordinate: newCoordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)


### PR DESCRIPTION
Closes: https://github.com/mapbox/MapboxNavigation.swift/issues/99

If the difference between the calculated course and the actual course is greater than a certain threshold, we should probably not manipulate the puck.

/cc @1ec5 @frederoni 