### PR TITLE
Add "master" pin to instructions for Cartfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pod 'Mapbox-iOS-SDK', '~> 3.4'
 Add the following line to your Cartfile:
 
 ```ruby
-github "mapbox/MapboxNavigation.swift"
+github "mapbox/MapboxNavigation.swift" "master"
 ```
 
 ### Gist of how this works


### PR DESCRIPTION
Proposed change to address #103. Is this necessary? Is another release due to replace (v0.0.4) soon enough?