### PR TITLE
Specify versions in pod dependencies

### DIFF
--- a/MapboxNavigationUI.swift.podspec
+++ b/MapboxNavigationUI.swift.podspec
@@ -43,11 +43,11 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigationUI"
 
   s.dependency "MapboxNavigation.swift"
-  s.dependency "MapboxDirections.swift"
-  s.dependency "MapboxGeocoder.swift"
-  s.dependency "Mapbox-iOS-SDK"
-  s.dependency "OSRMTextInstructions"
-  s.dependency "Pulley"
+  s.dependency "MapboxDirections.swift", "~> 0.8"
+  s.dependency "MapboxGeocoder.swift", "~> 0.6"
+  s.dependency "Mapbox-iOS-SDK", "~> 3.5"
+  s.dependency "OSRMTextInstructions", "~> 0.1"
+  s.dependency "Pulley", "~> 1.3"
   s.dependency "SDWebImage", "~> 4.0"
   s.dependency "AWSPolly", "~> 2.5"
 

--- a/MapboxNavigationUI.swift.podspec
+++ b/MapboxNavigationUI.swift.podspec
@@ -44,7 +44,6 @@ Pod::Spec.new do |s|
 
   s.dependency "MapboxNavigation.swift"
   s.dependency "MapboxDirections.swift", "~> 0.8"
-  s.dependency "MapboxGeocoder.swift", "~> 0.6"
   s.dependency "Mapbox-iOS-SDK", "~> 3.5"
   s.dependency "OSRMTextInstructions", "~> 0.1"
   s.dependency "Pulley", "~> 1.3"


### PR DESCRIPTION
This PR specifies minimum versions for each of the third-party library dependencies in the MapboxNavigationUI podspec. This is especially important because previous versions may be written in Swift 2.3. I left out a minimum version for MapboxNavigation.swift in this podspec, because MapboxNavigation.swift has yet to be pushed to CocoaPods trunk.

/cc @frederoni @bsudekum